### PR TITLE
Fix incorrect mention of inode/directory MIME type

### DIFF
--- a/data/org.pwmt.zathura-cb.desktop
+++ b/data/org.pwmt.zathura-cb.desktop
@@ -8,4 +8,4 @@ Icon=org.pwmt.zathura
 Terminal=false
 NoDisplay=true
 Categories=Office;Viewer;
-MimeType=application/x-cbr;application/x-rar;application/x-cbz;application/zip;application/x-cb7;application/x-7z-compressed;application/x-cbt;application/x-tar;inode/directory;
+MimeType=application/x-cbr;application/x-rar;application/x-cbz;application/zip;application/x-cb7;application/x-7z-compressed;application/x-cbt;application/x-tar;


### PR DESCRIPTION
Zathura-cb is designed to handle comic book files, not directories.